### PR TITLE
Curious missing arguments

### DIFF
--- a/include/thinks/fast_marching_method/fast_marching_method.hpp
+++ b/include/thinks/fast_marching_method/fast_marching_method.hpp
@@ -46,6 +46,11 @@ namespace thinks {
 namespace fast_marching_method {
 namespace detail {
 
+// forward decls
+template<std::size_t N>
+void ThrowIfZeroElementInSize(std::array<std::size_t, N> const& size);
+
+
 //! Returns the product of the elements in array @a size.
 //! Note: Not checking for integer overflow here!
 template<std::size_t N>
@@ -903,7 +908,7 @@ DistanceGridIndexFromDilationGridIndex(
   std::array<std::int32_t, N> const& dilation_grid_index)
 {
   auto distance_grid_index = dilation_grid_index;
-  for_each(begin(distance_grid_index), end(distance_grid_index),
+  std::for_each(begin(distance_grid_index), end(distance_grid_index),
            [](auto& d) { d -= int32_t{1}; });
   return distance_grid_index;
 }
@@ -916,7 +921,7 @@ DilationGridIndexFromDistanceGridIndex(
   std::array<std::int32_t, N> const& distance_grid_index)
 {
   auto dilation_grid_index = distance_grid_index;
-  for_each(begin(dilation_grid_index), end(dilation_grid_index),
+  std::for_each(begin(dilation_grid_index), end(dilation_grid_index),
            [](auto& d) { d += int32_t{1}; assert(d >= int32_t{0}); });
   return dilation_grid_index;
 }
@@ -2136,7 +2141,7 @@ public:
     return detail::SolveEikonal(
       index,
       distance_grid,
-      Speed(index),
+      this->Speed(index),
       this->grid_spacing());
   }
 };
@@ -2168,7 +2173,7 @@ public:
     return detail::HighAccuracySolveEikonal(
       index,
       distance_grid,
-      Speed(index),
+      this->Speed(index),
       this->grid_spacing());
   }
 };

--- a/test/eikonal_solvers_test.cpp
+++ b/test/eikonal_solvers_test.cpp
@@ -114,7 +114,9 @@ TYPED_TEST(UniformSpeedEikonalSolverTest, InvalidGridSpacingThrows)
       // Act.
       auto const ft = util::FunctionThrows<invalid_argument>(
         [=]() {
+          [[maybe_unused]]
           auto const eikonal_solver = EikonalSolverType(grid_spacing, speed);
+          // (void)eikonal_solver;  // pre-C++11
         });
 
       // Assert.
@@ -152,6 +154,7 @@ TYPED_TEST(UniformSpeedEikonalSolverTest, InvalidSpeedThrows)
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver = EikonalSolverType(grid_spacing, speed);
       });
 
@@ -196,6 +199,7 @@ TYPED_TEST(HighAccuracyUniformSpeedEikonalSolverTest, InvalidGridSpacingThrows)
       // Act.
       auto const ft = util::FunctionThrows<invalid_argument>(
         [=]() {
+          [[maybe_unused]]
           auto const eikonal_solver = EikonalSolverType(grid_spacing, speed);
         });
 
@@ -234,6 +238,7 @@ TYPED_TEST(HighAccuracyUniformSpeedEikonalSolverTest, InvalidSpeedThrows)
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver = EikonalSolverType(grid_spacing, speed);
       });
 
@@ -280,6 +285,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidGridSpacingThrows)
       // Act.
       auto const ft = util::FunctionThrows<invalid_argument>(
         [&]() {
+          [[maybe_unused]]
           auto const eikonal_solver =
             EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
         });
@@ -324,6 +330,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedThrows)
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver =
           EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
       });
@@ -359,6 +366,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedBufferThrows)
   // Act.
   auto const ft = util::FunctionThrows<invalid_argument>(
     [=]() {
+      [[maybe_unused]]
       auto const eikonal_solver =
         EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
     });
@@ -393,6 +401,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedGridSizeThrows)
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver =
           EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
       });
@@ -479,6 +488,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidGridSpacingThrows)
       // Act.
       auto const ft = util::FunctionThrows<invalid_argument>(
         [&]() {
+          [[maybe_unused]]
           auto const eikonal_solver =
             EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
         });
@@ -523,6 +533,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedThrows)
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver =
           EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
       });
@@ -557,6 +568,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedBufferThrows)
   // Act.
   auto const ft = util::FunctionThrows<invalid_argument>(
     [=]() {
+      [[maybe_unused]]
       auto const eikonal_solver =
         EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
     });
@@ -590,6 +602,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedGridSizeThrows
     // Act.
     auto const ft = util::FunctionThrows<invalid_argument>(
       [=]() {
+        [[maybe_unused]]
         auto const eikonal_solver =
           EikonalSolverType(grid_spacing, speed_grid_size, speed_buffer);
       });
@@ -671,6 +684,7 @@ TYPED_TEST(DistanceSolverTest, InvalidGridSpacingThrows)
       // Act.
       auto const ft = util::FunctionThrows<invalid_argument>(
         [=]() {
+          [[maybe_unused]]
           auto const eikonal_solver = EikonalSolverType(dx);
         });
 

--- a/test/eikonal_solvers_test.cpp
+++ b/test/eikonal_solvers_test.cpp
@@ -86,7 +86,7 @@ TYPED_TEST(UniformSpeedEikonalSolverTest, InvalidGridSpacingThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -128,7 +128,7 @@ TYPED_TEST(UniformSpeedEikonalSolverTest, InvalidSpeedThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -168,7 +168,7 @@ TYPED_TEST(HighAccuracyUniformSpeedEikonalSolverTest, InvalidGridSpacingThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyUniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -210,7 +210,7 @@ TYPED_TEST(HighAccuracyUniformSpeedEikonalSolverTest, InvalidSpeedThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyUniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -250,7 +250,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidGridSpacingThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -295,7 +295,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -338,7 +338,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedBufferThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -372,7 +372,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, InvalidSpeedGridSizeThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -407,7 +407,7 @@ TYPED_TEST(VaryingSpeedEikonalSolverTest, IndexOutsideSpeedGridThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -449,7 +449,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidGridSpacingThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyVaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -494,7 +494,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyVaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -537,7 +537,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedBufferThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyVaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -570,7 +570,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, InvalidSpeedGridSizeThrows
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyVaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -604,7 +604,7 @@ TYPED_TEST(HighAccuracyVaryingSpeedEikonalSolverTest, IndexOutsideSpeedGridThrow
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::HighAccuracyVaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -645,7 +645,7 @@ TYPED_TEST(DistanceSolverTest, InvalidGridSpacingThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::DistanceSolver<ScalarType, kDimension> EikonalSolverType;

--- a/test/signed_arrival_time_test.cpp
+++ b/test/signed_arrival_time_test.cpp
@@ -414,6 +414,7 @@ TYPED_TEST(SignedArrivalTimeTest, ContainedComponentThrows)
     grid_size,
     grid_spacing,
     [](ScalarType const d) { return d; },
+    0,  // dilation_pass_count
     &sphere_boundary_indices1,
     &sphere_boundary_times1);
   auto sphere_boundary_indices2 = vector<array<int32_t, kDimension>>();
@@ -424,6 +425,7 @@ TYPED_TEST(SignedArrivalTimeTest, ContainedComponentThrows)
     grid_size,
     grid_spacing,
     [](ScalarType const d) { return d; },
+    0,  // dilation_pass_count
     &sphere_boundary_indices2,
     &sphere_boundary_times2);
 

--- a/test/signed_arrival_time_test.cpp
+++ b/test/signed_arrival_time_test.cpp
@@ -549,7 +549,8 @@ TYPED_TEST(SignedArrivalTimeTest, VaryingSpeed)
     auto const index = time_index_iter.index();
     auto mid = true;
     for (auto i = size_t{1}; i < kDimension; ++i) {
-      if (index[i] != grid_size[i] / 2) {
+      const int32_t half = static_cast<int32_t>(grid_size[i]) / 2;
+      if (index[i] != half) {
         mid = false;
         break;
       }
@@ -646,7 +647,8 @@ TYPED_TEST(SignedArrivalTimeTest, BoxBoundary)
   while (index_iter.has_next()) {
     auto const index = index_iter.index();
     for (auto i = size_t{0}; i < kDimension; ++i) {
-      if (index[i] == 0 || index[i] == grid_size[i] - 1) {
+      const int32_t edge = static_cast<int32_t>(grid_size[i]) - 1;
+      if (index[i] == 0 || index[i] == edge) {
         boundary_indices.push_back(index);
         break;
       }
@@ -726,7 +728,8 @@ TYPED_TEST(SignedArrivalTimeTest, Checkerboard)
       if (!is_boundary(index)) {
         auto is_edge = false;
         for (auto i = size_t{0}; i < kDimension; ++i) {
-          if (index[i] == 0 || index[i] == grid_size[i] - 1) {
+          const int32_t edge = static_cast<int32_t>(grid_size[i]) - 1;
+          if (index[i] == 0 || index[i] == edge) {
             is_edge = true;
             break;
           }

--- a/test/signed_arrival_time_test.cpp
+++ b/test/signed_arrival_time_test.cpp
@@ -66,7 +66,7 @@ TYPED_TEST(SignedArrivalTimeTest, ZeroElementInGridSizeThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -106,7 +106,7 @@ TYPED_TEST(SignedArrivalTimeTest, EmptyBoundaryThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -138,7 +138,7 @@ TYPED_TEST(SignedArrivalTimeTest, FullGridBoundaryIndicesThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -179,7 +179,7 @@ TYPED_TEST(SignedArrivalTimeTest, DuplicateBoundaryIndicesThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -220,7 +220,7 @@ TYPED_TEST(SignedArrivalTimeTest, BoundaryIndexOutsideGridThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -263,7 +263,7 @@ TYPED_TEST(SignedArrivalTimeTest, BoundaryIndicesAndTimesSizeMismatchThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -302,7 +302,7 @@ TYPED_TEST(SignedArrivalTimeTest, InvalidBoundaryTimeThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -350,7 +350,7 @@ TYPED_TEST(SignedArrivalTimeTest, EikonalSolverFailThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -390,7 +390,7 @@ TYPED_TEST(SignedArrivalTimeTest, ContainedComponentThrows)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr auto kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -453,7 +453,7 @@ TYPED_TEST(SignedArrivalTimeTest, DifferentUniformSpeed)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -499,7 +499,7 @@ TYPED_TEST(SignedArrivalTimeTest, VaryingSpeed)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr auto kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::VaryingSpeedEikonalSolver<ScalarType, kDimension>
@@ -571,7 +571,7 @@ TYPED_TEST(SignedArrivalTimeTest, NonUniformGridSpacing)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -631,7 +631,7 @@ TYPED_TEST(SignedArrivalTimeTest, BoxBoundary)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -676,7 +676,7 @@ TYPED_TEST(SignedArrivalTimeTest, Checkerboard)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr auto kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -749,7 +749,7 @@ TYPED_TEST(SignedArrivalTimeTest, OverlappingBoxes)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr auto kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
@@ -818,7 +818,7 @@ TYPED_TEST(SignedArrivalTimeAccuracyTest, PointSourceAccuracy)
 {
   using namespace std;
 
-  typedef TypeParam::ScalarType ScalarType;
+  typedef typename TypeParam::ScalarType ScalarType;
   static constexpr auto kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
   typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>

--- a/test/util.hpp
+++ b/test/util.hpp
@@ -34,6 +34,9 @@
 
 namespace util {
 
+template<std::size_t N>
+class IndexIterator;
+
 template<typename S, std::size_t N>
 struct ScalarDimensionPair
 {


### PR DESCRIPTION
Adds values of '0' to the missing 'dilation_pass_count' argument in HyperSphereBoundaryCalls().